### PR TITLE
Fix duplicate page title bug for single posts

### DIFF
--- a/single.php
+++ b/single.php
@@ -12,7 +12,6 @@
 $context = Timber::get_context();
 $post = Timber::query_post();
 $context['post'] = $post;
-$context['wp_title'] .= ' - ' . $post->title();
 $context['comment_form'] = TimberHelper::get_comment_form();
 
 if ( post_password_required( $post->ID ) ) {


### PR DESCRIPTION
Site name + page title combo is already addressed in https://github.com/Upstatement/timber-starter-theme/blob/master/views/html-header.twig